### PR TITLE
infra: Add debugging tool in action(win build)

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -7,6 +7,13 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled.'
+        required: false
+        default: false
 
 jobs:
   build:
@@ -29,6 +36,10 @@ jobs:
       with:
         name: result
         path: build/src/thorvg*
+
+    - if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 15
 
   static_loaders:
     runs-on: windows-latest


### PR DESCRIPTION
tmate is a tool that helps debugging github actions. If ci fails, opens an ssh connection for debugging. It is difficult to predict the msvc dev environment of the window-latest image. This can be useful when problems occurs.

https://github.com/marketplace/actions/debugging-with-tmate